### PR TITLE
Link libdl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ set_target_properties(oclgrind PROPERTIES INSTALL_RPATH ${CLANG_ROOT}/lib)
 target_link_libraries(oclgrind PUBLIC ${CORE_EXTRA_LIBS} -Wl,-rpath,${CLANG_ROOT}/lib
   clangFrontend clangSerialization clangDriver clangCodeGen
   clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic
-  "${LLVM_LIBS}" Threads::Threads)
+  "${LLVM_LIBS}" Threads::Threads dl)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   target_link_libraries(oclgrind PRIVATE Version)


### PR DESCRIPTION
The docker image build fails, with error
```
/usr/bin/ld: liboclgrind.so: undefined reference to `dlclose'
/usr/bin/ld: liboclgrind.so: undefined reference to `dlsym'
/usr/bin/ld: liboclgrind.so: undefined reference to `dlopen'
/usr/bin/ld: liboclgrind.so: undefined reference to `dlerror'
/usr/bin/ld: liboclgrind.so: undefined reference to `dladdr'
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```

This links libdl to provide implementations for `dlopen` and similar.