### PR TITLE
SPIRV support

### DIFF
--- a/src/runtime/runtime.cpp
+++ b/src/runtime/runtime.cpp
@@ -5862,10 +5862,8 @@ clCreateProgramWithIL(cl_context context, const void* il, size_t length,
   spirv_file.write((const char*) il, length);
   spirv_file.close();
 
-  auto cmd = "llvm-spirv -r \"" + spirv_name + "\" -o \"" + llvmbc_name + "\""
+  auto cmd = "LD_PRELOAD='' llvm-spirv -r \"" + spirv_name + "\" -o \"" + llvmbc_name + "\""
              " 2>\"" + err_name + "\" > \"" + log_name + "\"";
-
-  std::cout << "running " << cmd << std::endl;
 
   std::cout << std::flush;
   int r = std::system(cmd.c_str());


### PR DESCRIPTION
This adds support for `clCreateProgramWithIL`. It expects the `llvm-spirv` tool to exist on the system, and will fall back to an API error if it doesn't exist or fails. All files and logs can be found in the `/tmp` folder.

As the SYCL programs weren't building without preloading libOpenCL, LD_PRELOAD is set in the docker images. This seems to cause a conflict with the translator. Instead of spending ages trying to sort out the whole mess of who defines what, I just clear the LD_PRELOAD value when running the translator.