### PR TITLE
Track opcode by ID instead of string

### DIFF
--- a/src/plugins/WorkloadCharacterisation.cpp
+++ b/src/plugins/WorkloadCharacterisation.cpp
@@ -148,8 +148,7 @@ void WorkloadCharacterisation::instructionExecuted(
     const TypedValue &result) {
 
   unsigned opcode = instruction->getOpcode();
-  std::string opcode_name = llvm::Instruction::getOpcodeName(opcode);
-  (*m_state.computeOps)[opcode_name]++;
+  (*m_state.computeOps)[opcode]++;
 
   bool isMemoryInst = false;
   unsigned addressSpace;
@@ -361,8 +360,8 @@ vector<double> parallelSpatialLocality(vector < vector < WorkloadCharacterisatio
 }
 
 void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocation) {
-  std::vector<std::pair<std::string, size_t>> sorted_ops(m_computeOps.size());
-  std::partial_sort_copy(m_computeOps.begin(), m_computeOps.end(), sorted_ops.begin(), sorted_ops.end(), [](const std::pair<std::string, size_t> &left, const std::pair<std::string, size_t> &right) {
+  std::vector<std::pair<unsigned, size_t>> sorted_ops(m_computeOps.size());
+  std::partial_sort_copy(m_computeOps.begin(), m_computeOps.end(), sorted_ops.begin(), sorted_ops.end(), [](const std::pair<unsigned, size_t> &left, const std::pair<unsigned, size_t> &right) {
     return (left.second > right.second);
   });
 
@@ -606,7 +605,7 @@ void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocati
 
   logfile << "opcode_counts,Compute,";
   for (const auto &item : sorted_ops) {
-    logfile << item.first << keyval_sep << item.second << list_delim;
+    logfile << llvm::Instruction::getOpcodeName(item.first) << keyval_sep << item.second << list_delim;
   }
   logfile << "\n";
 
@@ -698,7 +697,7 @@ void WorkloadCharacterisation::workGroupBegin(const WorkGroup *workGroup) {
     //m_state.memoryOps = new unordered_map<pair<size_t, bool>, uint32_t>;
     m_state.storeOps = new unordered_map<size_t, uint32_t>;
     m_state.loadOps = new unordered_map<size_t, uint32_t>;
-    m_state.computeOps = new unordered_map<std::string, size_t>;
+    m_state.computeOps = new unordered_map<unsigned, size_t>;
     m_state.branchOps = new unordered_map<const llvm::Instruction*, std::vector<bool>>;
     m_state.instructionsBetweenBarriers = new vector<uint32_t>;
     m_state.instructionWidth = new unordered_map<uint16_t, size_t>;

--- a/src/plugins/WorkloadCharacterisation.h
+++ b/src/plugins/WorkloadCharacterisation.h
@@ -55,7 +55,7 @@ private:
   // std::unordered_map<std::pair<size_t, bool>, uint32_t> m_memoryOps;
   std::unordered_map<size_t, uint32_t> m_storeOps;
   std::unordered_map<size_t, uint32_t> m_loadOps;
-  std::unordered_map<std::string, size_t> m_computeOps;
+  std::unordered_map<unsigned, size_t> m_computeOps;
   std::unordered_map<const llvm::Instruction *, std::unordered_map<uint16_t, uint32_t>> m_branchPatterns;
   std::unordered_map<const llvm::Instruction *, uint32_t> m_branchCounts;
   std::vector<uint32_t> m_instructionsToBarrier;
@@ -78,7 +78,7 @@ private:
   std::vector<std::vector<double>> m_psl_per_group;
 
   struct WorkerState {
-    std::unordered_map<std::string, size_t> *computeOps;
+    std::unordered_map<unsigned, size_t> *computeOps;
     //std::unordered_map<std::pair<size_t, bool>, uint32_t> *memoryOps;
     std::unordered_map<size_t, uint32_t> *storeOps;
     std::unordered_map<size_t, uint32_t> *loadOps;


### PR DESCRIPTION
AIWC keeps a map of opcode -> count when running kernel. Originally it used the string form of the opcode. This changes it to use the raw opcode itself (type is unsigned int), which is more natural as a representation for a primitive enum type.

Seems to be no significant performance difference, but that's fine. I much prefer not stringly representing values that don't absolutely need to be.